### PR TITLE
add option for setting output file name & chunk name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,14 @@ This plugin works perfectly with the `SplitByPathPlugin` plugin.
 ## About
 
 This plugin creates a list with the name, version, license, and link to the repo of each node module in the webpack bundle.  
-The output file is currently hardcoded and set to `npm-modules.md` in the webpack output directory.
 
 ## Usage
 
-Simply include this plugin in your webpack configuration file.
+Simply include this plugin in your webpack configuration file.  
+The output file name can be configured, and defaults to `npm-modules.md`
 
 ```
-const ExportNodeModules = require('webpack-node-modules-list'),
-  SplitByPathPlugin = require('webpack-split-by-path');
+const ExportNodeModules = require('webpack-node-modules-list');
 
 module.exports = {
 plugins: [

--- a/README.md
+++ b/README.md
@@ -3,15 +3,10 @@
 [![npm version](https://badge.fury.io/js/webpack-node-modules-list.svg)](https://badge.fury.io/js/webpack-node-modules-list)
 
 Exports metadata of all used node modules of a webpack bundle to a file.  
-This plugin works perfectly with the `SplitByPathPlugin` plugin.
-
-## About
-
-This plugin creates a list with the name, version, license, and link to the repo of each node module in the webpack bundle.  
 
 ## Usage
 
-Simply include this plugin in your webpack configuration file.  
+This plugin creates a list with the name, version, license, and link to the repo of each node module in the webpack bundle.  
 The output file name can be configured, and defaults to `npm-modules.md`
 
 ```
@@ -34,6 +29,9 @@ This option allows to filter the output so that it only includes chunks with a m
 This option allows to change the name of the output file. The file path is relative to the webpack output directory.
 
 #### Example
+
+This plugin works perfectly with the `SplitByPathPlugin` plugin.  
+The example below demonstrates all configurable features.
 
 ```
 const ExportNodeModules = require('webpack-node-modules-list'),

--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
+# Node Modules List Webpack Plugin
+
 [![npm version](https://badge.fury.io/js/webpack-node-modules-list.svg)](https://badge.fury.io/js/webpack-node-modules-list)
 
-Exports meta data of all used node modules of a webpack bundle to a file.
+Exports metadata of all used node modules of a webpack bundle to a file.  
+This plugin works perfectly with the `SplitByPathPlugin` plugin.
 
-Currently all included node modules of the webpack chunck `vendor` will be collected and the name, version, license and link to the repo will be written to a `npm-modules.md` file in the webpack output dir. This plugin works perfectly with `SplitByPathPlugin` plugin.
+## About
+
+This plugin creates a list with the name, version, license, and link to the repo of each node module in the webpack bundle.  
+The output file is currently hardcoded and set to `npm-modules.md` in the webpack output directory.
+
+## Usage
+
+Simply include this plugin in your webpack configuration file.
 
 ```
 const ExportNodeModules = require('webpack-node-modules-list'),
@@ -10,12 +20,26 @@ const ExportNodeModules = require('webpack-node-modules-list'),
 
 module.exports = {
 plugins: [
+  new ExportNodeModules()
+]}
+```
+
+Alternatively, it is possible to pass a chunk name to the constructor.  
+This allows to filter the output so that it only includes chunks with a matching chunk name.
+
+```
+const ExportNodeModules = require('webpack-node-modules-list'),
+  SplitByPathPlugin = require('webpack-split-by-path'),
+  chunkName = 'vendor';
+
+module.exports = {
+plugins: [
   new SplitByPathPlugin([
     {
-      name: 'vendor',
+      name: chunkName,
       path: path.join(__dirname, 'node_modules')
     }
   ]),
-  new ExportNodeModules()
+  new ExportNodeModules({chunkName})
 ]}
 ```

--- a/README.md
+++ b/README.md
@@ -24,8 +24,17 @@ plugins: [
 ]}
 ```
 
-Alternatively, it is possible to pass a chunk name to the constructor.  
-This allows to filter the output so that it only includes chunks with a matching chunk name.
+### Options
+
+An options object may be passed to the constructor.  
+
+#### options.chunkName
+This option allows to filter the output so that it only includes chunks with a matching chunk name.
+
+#### options.outputFile
+This option allows to change the name of the output file. The file path is relative to the webpack output directory.
+
+#### Example
 
 ```
 const ExportNodeModules = require('webpack-node-modules-list'),
@@ -40,6 +49,6 @@ plugins: [
       path: path.join(__dirname, 'node_modules')
     }
   ]),
-  new ExportNodeModules({chunkName})
+  new ExportNodeModules({chunkName, outputFile: 'npm.md'})
 ]}
 ```

--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 'use strict';
 
 const path = require('path'),
-  fs = require('fs');
+  fs = require('fs'),
+  defaultOptions = {
+    outputFile: 'npm-modules.md'
+  };
 
 function ExportNodeModules(options) {
-  options = options || {};
-
-  this.chunkName = options.chunkName;
-  this.outputFile = options.outputFile || 'npm-modules.md';
+  this.options = Object.assign({}, defaultOptions, options);
 }
 
 ExportNodeModules.prototype.apply = function(compiler) {
@@ -16,7 +16,7 @@ ExportNodeModules.prototype.apply = function(compiler) {
       npmModules = new Map();
 
     compilation.chunks.forEach(chunk => {
-      if(this.chunkName && this.chunkName !== chunk.name) {
+      if(this.options.chunkName && this.options.chunkName !== chunk.name) {
         return;
       }
 
@@ -52,7 +52,7 @@ ExportNodeModules.prototype.apply = function(compiler) {
       });
 
     // Insert this list into the Webpack build as a new file asset:
-    compilation.assets[this.outputFile] = {
+    compilation.assets[this.options.outputFile] = {
       source: function() {
         return npmModulesList;
       },

--- a/index.js
+++ b/index.js
@@ -1,39 +1,45 @@
 'use strict';
 
 const path = require('path'),
-  fs = require('fs'),
-  npmModules = new Map();
+  fs = require('fs');
 
-function ExportNodeModules() {}
+function ExportNodeModules(options) {
+  options = options || {};
+
+  this.chunkName = options.chunkName;
+}
 
 ExportNodeModules.prototype.apply = function(compiler) {
-  compiler.plugin('emit', function(compilation, callback) {
-    let npmModulesList = '';
+  compiler.plugin('emit', (compilation, callback) => {
+    let npmModulesList = '',
+      npmModules = new Map();
 
-    compilation.chunks.forEach(function(chunk) {
-      if (chunk.name === 'vendor') {
-        chunk.modules.forEach(function(module) {
-          const contextArray = module.context.split('/');
-
-          contextArray.splice(contextArray.indexOf('node_modules') + 2);
-
-          let packageJson = {},
-            context = contextArray.join('/'),
-            npmModule = contextArray[contextArray.indexOf('node_modules') + 1],
-            packageJsonFile = path.join(context, 'package.json');
-
-          if (fs.existsSync(packageJsonFile)) {
-            packageJson = JSON.parse(fs.readFileSync(packageJsonFile, 'UTF-8'));
-          }
-
-          npmModules.set(packageJson.name, {
-            name: packageJson.name,
-            version: packageJson.version,
-            homepage: packageJson.homepage,
-            license: getLicenses(packageJson)
-          });
-        });
+    compilation.chunks.forEach(chunk => {
+      if(this.chunkName && this.chunkName !== chunk.name) {
+        return;
       }
+
+      // exclude anything that isn't a node module
+      let modules = chunk.modules.filter(module =>
+        module.context.indexOf('node_modules') !== -1);
+
+      modules.forEach(function(module) {
+        const contextArray = module.context.split('/');
+
+        contextArray.splice(contextArray.indexOf('node_modules') + 2);
+
+        let context = contextArray.join('/'),
+          npmModule = contextArray[contextArray.indexOf('node_modules') + 1],
+          packageJsonFile = path.join(context, 'package.json'),
+          packageJson = JSON.parse(fs.readFileSync(packageJsonFile, 'UTF-8'));
+
+        npmModules.set(packageJson.name, {
+          name: packageJson.name,
+          version: packageJson.version,
+          homepage: packageJson.homepage,
+          license: getLicenses(packageJson)
+        });
+      });
     });
 
     Array.from(npmModules.keys())
@@ -41,7 +47,7 @@ ExportNodeModules.prototype.apply = function(compiler) {
       .map(key => npmModules.get(key))
       .forEach(module => {
         npmModulesList += `[${module.name}@${module.version}: ` +
-          `${module.license}](${module.homepage})\n`;
+          `${module.license}](${module.homepage})  \n`;
       });
 
     // Insert this list into the Webpack build as a new file asset:

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ function ExportNodeModules(options) {
   options = options || {};
 
   this.chunkName = options.chunkName;
+  this.outputFile = options.outputFile || 'npm-modules.md';
 }
 
 ExportNodeModules.prototype.apply = function(compiler) {
@@ -51,7 +52,7 @@ ExportNodeModules.prototype.apply = function(compiler) {
       });
 
     // Insert this list into the Webpack build as a new file asset:
-    compilation.assets['npm-modules.md'] = {
+    compilation.assets[this.outputFile] = {
       source: function() {
         return npmModulesList;
       },

--- a/index.js
+++ b/index.js
@@ -21,26 +21,26 @@ ExportNodeModules.prototype.apply = function(compiler) {
       }
 
       // exclude anything that isn't a node module
-      let modules = chunk.modules.filter(module =>
-        module.context.indexOf('node_modules') !== -1);
+      chunk.modules
+        .filter(module =>
+          module.context.indexOf('node_modules') !== -1)
+        .forEach(function(module) {
+          const contextArray = module.context.split('/');
 
-      modules.forEach(function(module) {
-        const contextArray = module.context.split('/');
+          contextArray.splice(contextArray.indexOf('node_modules') + 2);
 
-        contextArray.splice(contextArray.indexOf('node_modules') + 2);
+          let context = contextArray.join('/'),
+            npmModule = contextArray[contextArray.indexOf('node_modules') + 1],
+            packageJsonFile = path.join(context, 'package.json'),
+            packageJson = JSON.parse(fs.readFileSync(packageJsonFile, 'UTF-8'));
 
-        let context = contextArray.join('/'),
-          npmModule = contextArray[contextArray.indexOf('node_modules') + 1],
-          packageJsonFile = path.join(context, 'package.json'),
-          packageJson = JSON.parse(fs.readFileSync(packageJsonFile, 'UTF-8'));
-
-        npmModules.set(packageJson.name, {
-          name: packageJson.name,
-          version: packageJson.version,
-          homepage: packageJson.homepage,
-          license: getLicenses(packageJson)
+          npmModules.set(packageJson.name, {
+            name: packageJson.name,
+            version: packageJson.version,
+            homepage: packageJson.homepage,
+            license: getLicenses(packageJson)
+          });
         });
-      });
     });
 
     Array.from(npmModules.keys())


### PR DESCRIPTION
This PR adds an optional `options` object as parameter to the constructor.
The module now automatically ignores modules which are not containing in a `node_modules` folder.
If no options are provided, the module will collect node modules from all chunks.
If a chunk name is provided via the `options` object, only modules in chunks with the given name will be collected.
The `options` object also allows setting a different output file name, but still defaults to `npm-modules.md`.
