### PR TITLE
handle null context

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ ExportNodeModules.prototype.apply = function(compiler) {
       // exclude anything that isn't a node module
       chunk.modules
         .filter(module =>
-          module.context.indexOf('node_modules') !== -1)
+          module.context && module.context.indexOf('node_modules') !== -1)
         .forEach(function(module) {
           const contextArray = module.context.split('/');
 


### PR DESCRIPTION
`module.context` can be null in some cases, which breaks this plugin.
