### PR TITLE
handle packageJson.licenses as an object

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ function getLicenses(packageJson) {
       .map(license => license.type)
       .join(', ');
   } else if (packageJson.licenses) {
+    // TODO: Refactor this to reduce duplicate code. Note "licenses" vs "license".
     return (packageJson.licenses && packageJson.licenses.type) ||
       packageJson.licenses;
   }

--- a/index.js
+++ b/index.js
@@ -74,10 +74,13 @@ module.exports = ExportNodeModules;
  * @return {String}
  */
 function getLicenses(packageJson) {
-  if (packageJson.licenses) {
+  if (packageJson.licenses && packageJson.licenses instanceof Array) {
     return packageJson.licenses
       .map(license => license.type)
       .join(', ');
+  } else if (packageJson.licenses) {
+    return (packageJson.licenses && packageJson.licenses.type) ||
+      packageJson.licenses;
   }
 
   return (packageJson.license && packageJson.license.type) ||


### PR DESCRIPTION
Ran into a bug where `packageJson.licenses` can be an object instead of an array, and then we fail to run `.map` against it. Not sure if my fix is especially good, but it does seem to work.