### PR TITLE
ignore missing package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,17 +29,24 @@ ExportNodeModules.prototype.apply = function(compiler) {
 
           contextArray.splice(contextArray.indexOf('node_modules') + 2);
 
-          let context = contextArray.join('/'),
-            npmModule = contextArray[contextArray.indexOf('node_modules') + 1],
-            packageJsonFile = path.join(context, 'package.json'),
-            packageJson = JSON.parse(fs.readFileSync(packageJsonFile, 'UTF-8'));
+          try {
+            let context = contextArray.join('/'),
+              npmModule = contextArray[contextArray.indexOf('node_modules') + 1],
+              packageJsonFile = path.join(context, 'package.json'),
+              packageJson = JSON.parse(fs.readFileSync(packageJsonFile, 'UTF-8'));
 
-          npmModules.set(packageJson.name, {
-            name: packageJson.name,
-            version: packageJson.version,
-            homepage: packageJson.homepage,
-            license: getLicenses(packageJson)
-          });
+            npmModules.set(packageJson.name, {
+              name: packageJson.name,
+              version: packageJson.version,
+              homepage: packageJson.homepage,
+              license: getLicenses(packageJson)
+            });
+          } catch (err) {
+            // ignore errors if package.json didn't exist for this module
+            if (err.code !== 'ENOENT') {
+              throw err;
+            }
+          }
         });
     });
 


### PR DESCRIPTION
This is a sort of ugly "fix" to an issue I've been encountering. I'm open to suggestions for a better way to handle this.

```
"./node_modules/.bin/webpack" \
          --colors \
          --verbose \
          --devtool inline-source-map \
          --progress \
          --display-chunks \
          --optimize-dedupe \
          --bail                     90% optimize assetsfs.js:634
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^

Error: ENOENT: no such file or directory, open '***\node_modules\***\lib\package.json'
    at Error (native)
    at Object.fs.openSync (fs.js:634:18)
    at Object.fs.readFileSync (fs.js:502:33)
    at ***\node_modules\webpack-node-modules-list\index.js:35:41
    at Array.forEach (native)
    at compilation.chunks.forEach.chunk (***\node_modules\webpack-node-modules-list\index.js:27:10)
    at Array.forEach (native)
    at Compiler.compiler.plugin (***\node_modules\webpack-node-modules-list\index.js:18:24)
```