### PR TITLE
use path.sep for Windows compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,11 +25,11 @@ ExportNodeModules.prototype.apply = function(compiler) {
         .filter(module =>
           module.context && module.context.indexOf('node_modules') !== -1)
         .forEach(function(module) {
-          const contextArray = module.context.split('/');
+          const contextArray = module.context.split(path.sep);
 
           contextArray.splice(contextArray.indexOf('node_modules') + 2);
 
-          let context = contextArray.join('/'),
+          let context = contextArray.join(path.sep),
             npmModule = contextArray[contextArray.indexOf('node_modules') + 1],
             packageJsonFile = path.join(context, 'package.json'),
             packageJson = JSON.parse(fs.readFileSync(packageJsonFile, 'UTF-8'));


### PR DESCRIPTION
This replaces https://github.com/ubilabs/webpack-node-modules-list/pull/6