### PR TITLE
add json output format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,6 @@ plugins: [
       path: path.join(__dirname, 'node_modules')
     }
   ]),
-  new ExportNodeModules({chunkName, outputFile: 'npm', format: 'md'})
+  new ExportNodeModules({chunkName, outputFile: 'npm', format: 'markdown'})
 ]}
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This option allows to filter the output so that it only includes chunks with a m
 This option allows to change the name of the output file. The file path is relative to the webpack output directory.
 
 #### options.format
-This option allows to change the output format. md (markdown) and json are supported.
+This option allows to change the output format. `markdown` and `json` are supported.
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![npm version](https://badge.fury.io/js/webpack-node-modules-list.svg)](https://badge.fury.io/js/webpack-node-modules-list)
 
-Exports metadata of all used node modules of a webpack bundle to a file.  
+Exports metadata of all used node modules of a webpack bundle to a file.
 
 ## Usage
 
-This plugin creates a list with the name, version, license, and link to the repo of each node module in the webpack bundle.  
+This plugin creates a list with the name, version, license, and link to the repo of each node module in the webpack bundle.
 The output file name can be configured, and defaults to `npm-modules.md`
 
 ```
@@ -20,7 +20,7 @@ plugins: [
 
 ### Options
 
-An options object may be passed to the constructor.  
+An options object may be passed to the constructor.
 
 #### options.chunkName
 This option allows to filter the output so that it only includes chunks with a matching chunk name.
@@ -28,9 +28,12 @@ This option allows to filter the output so that it only includes chunks with a m
 #### options.outputFile
 This option allows to change the name of the output file. The file path is relative to the webpack output directory.
 
+#### options.format
+This option allows to change the output format. md (markdown) and json are supported.
+
 #### Example
 
-This plugin works perfectly with the `SplitByPathPlugin` plugin.  
+This plugin works perfectly with the `SplitByPathPlugin` plugin.
 The example below demonstrates all configurable features.
 
 ```
@@ -46,6 +49,6 @@ plugins: [
       path: path.join(__dirname, 'node_modules')
     }
   ]),
-  new ExportNodeModules({chunkName, outputFile: 'npm.md'})
+  new ExportNodeModules({chunkName, outputFile: 'npm', format: 'md'})
 ]}
 ```

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const path = require('path'),
   fs = require('fs'),
   defaultOptions = {
     outputFile: 'npm-modules',
-    format: 'md'
+    format: 'markdown'
   };
 
 function ExportNodeModules(options) {
@@ -15,7 +15,8 @@ ExportNodeModules.prototype.apply = function(compiler) {
   compiler.plugin('emit', (compilation, callback) => {
     let npmModulesList = '',
       npmModules = new Map(),
-      npmModulesJsonList = [];
+      npmModulesJsonList = [],
+      extension;
 
     compilation.chunks.forEach(chunk => {
       if(this.options.chunkName && this.options.chunkName !== chunk.name) {
@@ -49,9 +50,10 @@ ExportNodeModules.prototype.apply = function(compiler) {
       .sort()
       .map(key => npmModules.get(key))
       .forEach(module => {
-        if (this.options.format === 'md') {
-        npmModulesList += `[${module.name}@${module.version}: ` +
-          `${module.license}](${module.homepage})  \n`;
+        if (this.options.format === 'markdown') {
+          npmModulesList += `[${module.name}@${module.version}: ` +
+            `${module.license}](${module.homepage})  \n`;
+          extension = 'md';
         } else if (this.options.format === 'json') {
           npmModulesJsonList.push({
             name: module.name,
@@ -60,13 +62,14 @@ ExportNodeModules.prototype.apply = function(compiler) {
             source: module.homepage
           });
           npmModulesList = JSON.stringify(npmModulesJsonList, null, 2);
+          extension = 'json';
         } else {
           throw new Error(`Format "${this.options.format}" is not supported by webpack-node-modules-list.`);
         }
       });
 
     // Insert this list into the Webpack build as a new file asset:
-    compilation.assets[`${this.options.outputFile}.${this.options.format}`] = {
+    compilation.assets[`${this.options.outputFile}.${extension}`] = {
       source: function() {
         return npmModulesList;
       },


### PR DESCRIPTION
@yfr curious what you think about this. My alternative would be to have my build scripts do a postprocessing step on the markdown to convert it to json, but it would be nicer (for me) if the webpack plugin can natively generate json.