### PR TITLE
Fix deprecation warning in Webpack 3 (backwards compatible)

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,8 +23,9 @@ ExportNodeModules.prototype.apply = function(compiler) {
         return;
       }
 
+      let chunkModules = chunk.getModules ? chunk.getModules() : chunk.modules;
       // exclude anything that isn't a node module
-      chunk.modules
+      chunkModules
         .filter(module =>
           module.context && module.context.indexOf('node_modules') !== -1)
         .forEach(function(module) {


### PR DESCRIPTION
Fixes this deprecation warning in Webpack 3, while remaining compatible for earlier webpack versions:

```
DeprecationWarning: Chunk.modules is deprecated. Use Chunk.getNumberOfModules/mapModules/forEachModule/containsModule instead.
```

Otherwise, this plugin is working great in Webpack 3. Thank you.