### PR TITLE
feat: support webpack 4 and scoped packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,89 +1,46 @@
-'use strict';
+"use strict";
 
-const path = require('path'),
-  fs = require('fs'),
+const path = require("path"),
+  fs = require("fs"),
   defaultOptions = {
-    outputFile: 'npm-modules',
-    format: 'markdown'
+    outputFile: "npm-modules",
+    format: "markdown"
   };
 
-function ExportNodeModules(options) {
-  this.options = Object.assign({}, defaultOptions, options);
+
+function* capitlizeFirstLetter(str) {
+  for (let [i, l] of Array.from(str).entries()) {
+    yield (i === 0) ? l.toUpperCase() : l;
+  }
 }
 
-ExportNodeModules.prototype.apply = function(compiler) {
-  compiler.plugin('emit', (compilation, callback) => {
-    let npmModulesList = '',
-      npmModules = new Map(),
-      npmModulesJsonList = [],
-      extension;
+function* capitalizeWordsArray(rest) {
+  for (let word of rest) {
+    yield* capitlizeFirstLetter(word);
+  }
+}
 
-    compilation.chunks.forEach(chunk => {
-      if(this.options.chunkName && this.options.chunkName !== chunk.name) {
-        return;
-      }
+function kebbabCase2CamelCase(str) {
+  const strArr = str.split("-");
+  if (strArr.length < 2) return str;
+  let [first, ...rest] = strArr;
+  const restGen = capitalizeWordsArray(rest);
+  return [first, ...restGen].join("");
+}
 
-      let chunkModules = chunk.getModules ? chunk.getModules() : chunk.modules;
-      // exclude anything that isn't a node module
-      chunkModules
-        .filter(module =>
-          module.context && module.context.indexOf('node_modules') !== -1)
-        .forEach(function(module) {
-          const contextArray = module.context.split(path.sep);
-
-          contextArray.splice(contextArray.indexOf('node_modules') + 2);
-
-          let context = contextArray.join(path.sep),
-            npmModule = contextArray[contextArray.indexOf('node_modules') + 1],
-            packageJsonFile = path.join(context, 'package.json'),
-            packageJson = JSON.parse(fs.readFileSync(packageJsonFile, 'UTF-8'));
-
-          npmModules.set(packageJson.name, {
-            name: packageJson.name,
-            version: packageJson.version,
-            homepage: packageJson.homepage,
-            license: getLicenses(packageJson)
-          });
-        });
-    });
-
-    Array.from(npmModules.keys())
-      .sort()
-      .map(key => npmModules.get(key))
-      .forEach(module => {
-        if (this.options.format === 'markdown') {
-          npmModulesList += `[${module.name}@${module.version}: ` +
-            `${module.license}](${module.homepage})  \n`;
-          extension = 'md';
-        } else if (this.options.format === 'json') {
-          npmModulesJsonList.push({
-            name: module.name,
-            type: module.license,
-            version: module.version,
-            source: module.homepage
-          });
-          npmModulesList = JSON.stringify(npmModulesJsonList, null, 2);
-          extension = 'json';
-        } else {
-          throw new Error(`Format "${this.options.format}" is not supported by webpack-node-modules-list.`);
-        }
-      });
-
-    // Insert this list into the Webpack build as a new file asset:
-    compilation.assets[`${this.options.outputFile}.${extension}`] = {
-      source: function() {
-        return npmModulesList;
-      },
-      size: function() {
-        return npmModulesList.length;
-      }
-    };
-
-    callback();
-  });
-};
-
-module.exports = ExportNodeModules;
+function compatAddPlugin(tappable, pluginName, hookName, callback, async = false, forType = null) {
+  const method = (async) ? "tapAsync" : "tap";
+  if (tappable.hooks) {
+    hookName = kebbabCase2CamelCase(hookName);
+    if (forType) {
+      tappable.hooks[hookName][method](forType, pluginName, callback);
+    } else {
+      tappable.hooks[hookName][method](pluginName, callback);
+    }
+  } else {
+    tappable.plugin(hookName, callback);
+  }
+}
 
 /**
  * Extracts and returns the license/licenses abbrevations
@@ -94,8 +51,8 @@ module.exports = ExportNodeModules;
 function getLicenses(packageJson) {
   if (packageJson.licenses && packageJson.licenses instanceof Array) {
     return packageJson.licenses
-      .map(license => license.type)
-      .join(', ');
+    .map(license => license.type)
+    .join(", ");
   } else if (packageJson.licenses) {
     // TODO: Refactor this to reduce duplicate code. Note "licenses" vs "license".
     return (packageJson.licenses && packageJson.licenses.type) ||
@@ -105,3 +62,91 @@ function getLicenses(packageJson) {
   return (packageJson.license && packageJson.license.type) ||
     packageJson.license;
 }
+
+class ExportNodeModules {
+  constructor(options) {
+    this.options = Object.assign({}, defaultOptions, options);
+  }
+
+  apply(compiler) {
+    compatAddPlugin(compiler, ExportNodeModules.name, "emit", (compilation, callback) => {
+      let npmModulesList = "",
+        npmModules = new Map(),
+        npmModulesJsonList = [],
+        extension;
+
+      compilation.chunks.forEach(chunk => {
+        if (chunk.modulesIterable instanceof Set === false || (this.options.chunkName && this.options.chunkName !== chunk.name)) {
+          return;
+        }
+
+        let chunkModules = chunk.getModules ? chunk.getModules() : chunk.modules;
+        for (let module of chunkModules) {
+          // exclude anything that isn't a node module
+          if (module.context && module.context.indexOf("node_modules") !== -1) {
+            const contextArray = module.context.split(path.sep);
+            const packageNameStart = contextArray.indexOf("node_modules") + 1;
+            const nodeModulesArray = contextArray.slice(0, packageNameStart);
+            const firstPackageName = contextArray.slice(packageNameStart, packageNameStart + 1)[0];
+            const packageNameEnd = packageNameStart + (firstPackageName.indexOf("@") ? 1 : 2); //scoped packages
+
+            const packageName = contextArray.slice(packageNameStart, packageNameEnd);
+
+            const packageJsonFile = path.join(...nodeModulesArray, ...packageName, "package.json");
+            let packageJson;
+            try {
+              packageJson = JSON.parse(fs.readFileSync(packageJsonFile, "UTF-8"));
+            } catch {
+              console.warn(`could not read and parse package.json for package ${packageName}`);
+              continue;
+            }
+            npmModules.set(packageJson.name, {
+              name: packageJson.name,
+              version: packageJson.version,
+              homepage: packageJson.homepage,
+              license: getLicenses(packageJson)
+            });
+          }
+        }
+      });
+
+      Array.from(npmModules.keys())
+      .sort()
+      .map(key => npmModules.get(key))
+      .forEach(module => {
+        if (this.options.format === "markdown") {
+          npmModulesList += `[${module.name}@${module.version}: ` +
+            `${module.license}](${module.homepage})  \n`;
+          extension = "md";
+        } else if (this.options.format === "json") {
+          npmModulesJsonList.push({
+            name: module.name,
+            type: module.license,
+            version: module.version,
+            source: module.homepage
+          });
+          npmModulesList = JSON.stringify(npmModulesJsonList, null, 2);
+          extension = "json";
+        } else {
+          throw new Error(`Format "${this.options.format}" is not supported by webpack-node-modules-list.`);
+        }
+      });
+
+
+      // Insert this list into the Webpack build as a new file asset:
+      compilation.assets[`${this.options.outputFile}.${extension}`] = {
+        source: function() {
+          return npmModulesList;
+        },
+        size: function() {
+          return npmModulesList.length;
+        }
+      };
+
+      callback();
+    }, true);
+  };
+}
+
+module.exports = ExportNodeModules;
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "webpack-node-modules-list",
+  "version": "0.2.0",
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
hey there
I did a bunch of modernizations... 
added scoped package support and backwards compatible webpack 4 support
code reformatted by accident with prettier, if you want i'll rebase to remove that, but it does look better now IMHO
the webpack3/4 addCompatPlugin is something i've done too many times I guess I need to release it as it's own package... could extract this if you feel the need